### PR TITLE
Typo Corrections

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -72,7 +72,7 @@ See `examples/mod.lua` for an example of how to define the content of your mod. 
 
 ## exports.txt
 
-Several global values are made available to your mod, to allow you to refer to built-in content from the core gaem. These are all listed in `exports.txt` - the symbols there are verbatim how to refer to things, e.g. to refer to a Butterfly you would use `triggers.butterfly`.
+Several global values are made available to your mod, to allow you to refer to built-in content from the core game. These are all listed in `exports.txt` - the symbols there are verbatim how to refer to things, e.g. to refer to a Butterfly you would use `triggers.butterfly`.
 
 The exports can and will change as the game receives updates. We'll try to make sure these changes are always backwards compatible, but we can't make any guarantees that such changes **won't** occur.
 

--- a/examples/mod.lua
+++ b/examples/mod.lua
@@ -538,7 +538,7 @@ define_starter_pack {
 define_starter_pack {
     id = 3,
     name = "Oops!!! All Cheese!!!",
-    desc = "THE JUGGLERNAUT",
+    desc = "The Dairy Dimension",
     texture = triggers.cheese.texture,
     drafts = {
         oops_all_cheese,


### PR DESCRIPTION
in docs.md
changes gaem to game

in examples/mod.lua
changes duplicate "THE JUGGLERNAUT" to "The Dairy Dimension"